### PR TITLE
Add transaction timing output

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ The Fastest Blockchain, Powered by GPUs
 1. Run `python bruteforce.py` and enter a transaction amount when prompted.
 2. The script generates a random sender/recipient, computes a hashed block using a
    24‑bit seed and verifies the transaction immediately.
+3. After verification, the script prints how long the transaction computation took.
 
 PyTorch is used if available for GPU acceleration. If it is not installed, the
 scripts fall back to CPU with `numpy`.

--- a/bruteforce.py
+++ b/bruteforce.py
@@ -18,5 +18,6 @@ if hash.to_numpy(hashed_block_check).tolist() == hash.to_numpy(hash.hashed_block
     print(f"Actual transaction amount: {float(transaction_amount)}")
     print(f"Actual seed: {int(seed)}")
     print(f"Transaction ID: {tx_id_check}")
+    print(f"Transaction computation time: {hash.transaction_time:.6f} seconds")
 else:
     print("Transaction verification failed")

--- a/hash.py
+++ b/hash.py
@@ -3,6 +3,7 @@
 
 import hashlib
 import secrets
+import time
 
 try:
     import torch
@@ -91,8 +92,11 @@ def generate_hashed_block(sender_address, recipient_address, transaction_amount,
     tx_id = hashlib.blake2b(to_numpy(hashed_block).tobytes()).hexdigest()
     return sender_address, recipient_address, transaction_amount, seed, transaction_tensor, hashed_block, tx_id
 
+# Measure the time required to generate the hashed block
+_start = time.perf_counter()
 sender_address, recipient_address, transaction_amount, seed, transaction_tensor, hashed_block, transaction_id = generate_hashed_block(
     sender_address, recipient_address, transaction_amount, rand_seed
 )
+transaction_time = time.perf_counter() - _start
 #print(hashed_block)
 


### PR DESCRIPTION
## Summary
- time hashed block generation and expose duration
- show the transaction time in the verification output
- document timing feature in README

## Testing
- `python bruteforce.py <<'EOF'
1.0
EOF`

------
https://chatgpt.com/codex/tasks/task_e_684038036a208320a9ba12d3be85e4f7